### PR TITLE
Attachments validation

### DIFF
--- a/src/components/flow/actions/sendmsg/SendMsgForm.tsx
+++ b/src/components/flow/actions/sendmsg/SendMsgForm.tsx
@@ -45,7 +45,11 @@ import { Trans } from 'react-i18next';
 
 const MAX_ATTACHMENTS = 3;
 
-const TYPE_OPTIONS: SelectOption[] = [{ value: 'image', label: 'Image URL' }];
+const TYPE_OPTIONS: SelectOption[] = [
+  { value: 'image', label: 'Image URL' },
+  { value: 'audio', label: 'Audio URL' },
+  { value: 'video', label: 'Video URL' }
+];
 
 const NEW_TYPE_OPTIONS = TYPE_OPTIONS.concat([{ value: 'upload', label: 'Upload Attachment' }]);
 
@@ -257,19 +261,24 @@ export default class SendMsgForm extends React.Component<ActionFormProps, SendMs
     let message = '';
     let isValid = true;
     const file = files[0];
-    const fileName = file.name
-      .split('.')
-      .pop()
-      .toLowerCase();
+    const fileType = file.type.split('/')[0];
+    const fileEncoding = file.type.split('/')[1];
 
-    if (!['bmp', 'gif', 'png', 'jpg', 'jpeg'].includes(fileName)) {
+    if (!['audio', 'video', 'image'].includes(fileType)) {
       title = 'Invalid Attachment';
-      message = 'Attachments must be an image.';
+      message = 'Attachments must be either video, audio, or an image.';
       isValid = false;
-    } else if (file.size > 512000) {
+    } else if (
+      fileType === 'audio' &&
+      !['mp3', 'm4a', 'x-m4a', 'wav', 'ogg', 'oga'].includes(fileEncoding)
+    ) {
+      title = 'Invalid Format';
+      message = 'Audio attachments must be encoded as mp3, m4a, wav, ogg or oga files.';
+      isValid = false;
+    } else if ((fileType === 'image' && file.size > 512000) || file.size > 20971520) {
       title = 'File Size Exceeded';
       message =
-        'The file size should be less than 500kB for images. Please choose another file and try again.';
+        'The file size should be less than 500kB for images and less than 20MB for audio and video files. Please choose another file and try again.';
       isValid = false;
     }
 

--- a/src/components/flow/props.ts
+++ b/src/components/flow/props.ts
@@ -2,7 +2,7 @@ import { Type } from 'config/interfaces';
 import { AnyAction, ContactProperties, FlowIssue } from 'flowTypes';
 import { Asset, AssetStore, AssetType, RenderNode } from 'store/flowContext';
 import { NodeEditorSettings } from 'store/nodeEditor';
-import { DispatchWithState, GetState } from 'store/thunks';
+import { DispatchWithState, GetState, MergeEditorState } from 'store/thunks';
 import { titleCase } from 'utils';
 import { CompletionSchema } from 'utils/completion';
 
@@ -25,6 +25,9 @@ export interface ActionFormProps extends IssueProps {
     action: AnyAction,
     onUpdated?: (dispatch: DispatchWithState, getState: GetState) => void
   ): void;
+
+  // alert notifications
+  mergeEditorState?: MergeEditorState;
 
   // modal notifiers
   onTypeChange(config: Type): void;

--- a/src/components/nodeeditor/NodeEditor.tsx
+++ b/src/components/nodeeditor/NodeEditor.tsx
@@ -80,6 +80,8 @@ export interface FormProps {
   typeConfig?: Type;
   onTypeChange?(config: Type): void;
   onClose?(canceled: boolean): void;
+
+  mergeEditorState?: MergeEditorState;
 }
 
 /* export interface LocalizationProps {
@@ -180,6 +182,7 @@ export class NodeEditor extends React.Component<NodeEditorProps> {
         helpArticles: this.props.helpArticles,
         issues: this.props.issues.filter((issue: FlowIssue) => !issue.language),
         typeConfig: this.props.typeConfig,
+        mergeEditorState: this.props.mergeEditorState,
         onTypeChange: this.props.handleTypeConfigChange,
         onClose: this.close
       };


### PR DESCRIPTION
Added attachment file validation. Now allowed only images and file sizes limited to 500kB.
Reused modal alert from floweditor to display validation errors.
Task: https://app.asana.com/0/1152254835058569/1172381037876937/f
Task: https://app.asana.com/0/1152254835058569/1172381037876939/f
